### PR TITLE
Fix artifact upload action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,8 +50,9 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: ./build/client
 
   deploy:


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` to upload the build artifact for GitHub Pages

## Testing
- `npm test` *(fails: Missing script)*