### PR TITLE
Fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "react-router dev --host",
-    "build": "tsc -b && react-router build",
+    "build": "react-router typegen && tsc -b && react-router build",
     "lint": "yarn lint:eslint && yarn lint:prettier",
     "lint:eslint": "eslint src --max-warnings 0",
     "lint:prettier": "prettier --check src",


### PR DESCRIPTION
## Summary
- run `react-router typegen` before TypeScript build

## Testing
- `yarn build` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*