### PR TITLE
Remove prefix from routes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Build
-        run: docker compose exec -T frontend yarn build
+        run: docker compose exec -e NODE_ENV=production -T frontend yarn build
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Stop container

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -3,19 +3,16 @@ import {
   route,
   index,
   layout,
-  prefix,
 } from "@react-router/dev/routes";
 
 export default [
   layout("./layout.tsx", [
-    ...prefix("iccv2025", [
-      index("./routes/Home.tsx"),
-      route("/call-for-papers", "./routes/CallForPapers.tsx"),
-      // route("/schedule", "./routes/Schedule.tsx"),
-      route("/program", "./routes/Program.tsx"),
-      route("/organizers", "./routes/Organizers.tsx"),
-      // route("/past-events", "./routes/PastEvents.tsx"),
-      route("/contact", "./routes/Contact.tsx"),
-    ]),
+    index("./routes/Home.tsx"),
+    route("/call-for-papers", "./routes/CallForPapers.tsx"),
+    // route("/schedule", "./routes/Schedule.tsx"),
+    route("/program", "./routes/Program.tsx"),
+    route("/organizers", "./routes/Organizers.tsx"),
+    // route("/past-events", "./routes/PastEvents.tsx"),
+    route("/contact", "./routes/Contact.tsx"),
   ]),
 ] satisfies RouteConfig;

--- a/src/app/routes/CallForPapers.tsx
+++ b/src/app/routes/CallForPapers.tsx
@@ -217,7 +217,7 @@ function CallForPapers() {
           </p>
         </div>
         <Button variant="outline" asChild>
-          <Link to="/iccv2025/contact">Contact Us</Link>
+          <Link to="/contact">Contact Us</Link>
         </Button>
       </section>
     </main>

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -28,10 +28,10 @@ function Home() {
         </div>
         <div className="flex flex-col sm:flex-row gap-4">
           <Button asChild size="lg">
-            <Link to="/iccv2025/call-for-papers">Submit Paper</Link>
+            <Link to="/call-for-papers">Submit Paper</Link>
           </Button>
           <Button variant="outline" size="lg" asChild>
-            <Link to="/iccv2025/program">Check Program</Link>
+            <Link to="/program">Check Program</Link>
           </Button>
         </div>
       </section>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
       <div className="container grid gap-8 md:grid-cols-2 lg:grid-cols-4">
         {/* Logo and Workshop Name */}
         <div className="flex flex-col gap-2">
-          <Link to="/iccv2025" className="flex items-center space-x-2">
+          <Link to="/" className="flex items-center space-x-2">
             <span className="font-bold text-lg">LIMIT Workshop</span>
           </Link>
           <p className="text-sm text-muted-foreground">ICCV 2025</p>
@@ -111,25 +111,25 @@ export function Footer() {
         <div className="flex flex-col gap-2">
           <h3 className="font-medium">Links</h3>
           <Link
-            to="/iccv2025"
+            to="/"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             Home
           </Link>
           <Link
-            to="/iccv2025/call-for-papers"
+            to="/call-for-papers"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             Call for Papers
           </Link>
           <Link
-            to="/iccv2025/program"
+            to="/program"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             Program
           </Link>
           <Link
-            to="/iccv2025/contact"
+            to="/contact"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             Contact

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -12,13 +12,13 @@ import {
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from "./ui/sheet";
 
 const navItems = [
-  { name: "Home", path: "/iccv2025" },
-  { name: "Call for Papers", path: "/iccv2025/call-for-papers" },
-  // { name: "Schedule", path: "/iccv2025/schedule" },
-  { name: "Program", path: "/iccv2025/program" },
-  { name: "Organizers", path: "/iccv2025/organizers" },
-  // { name: "Past Events", path: "/iccv2025/past-events" },
-  { name: "Contact", path: "/iccv2025/contact" },
+  { name: "Home", path: "/" },
+  { name: "Call for Papers", path: "/call-for-papers" },
+  // { name: "Schedule", path: "/schedule" },
+  { name: "Program", path: "/program" },
+  { name: "Organizers", path: "/organizers" },
+  // { name: "Past Events", path: "/past-events" },
+  { name: "Contact", path: "/contact" },
 ];
 
 export function Header() {
@@ -26,7 +26,7 @@ export function Header() {
     <header className="top-0 z-50 w-full border-b border-border bg-header-background/70 backdrop-blur-md flex justify-center">
       <div className="container flex h-16 items-center justify-between px-5">
         <div className="flex items-center gap-2">
-          <Link to="/iccv2025" className="flex items-center space-x-2">
+          <Link to="/" className="flex items-center space-x-2">
             <span className="font-bold text-xl">LIMIT 2025</span>
           </Link>
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from 'vite'
 
+const isProd = process.env.NODE_ENV === 'production';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [reactRouter(), tailwindcss()],
@@ -11,5 +13,6 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  base: "/LIMIT/",
+  // Use "/LIMIT/" when building for GitHub Pages, "/" during dev
+  base: isProd ? '/LIMIT/' : '/',
 })


### PR DESCRIPTION
## Summary
- show the site at `/LIMIT/` by removing the `/iccv2025` prefix
- update all navigation links and routes accordingly

## Testing
- `yarn lint` *(fails: package missing in lockfile)*