### PR TITLE
feat: add build condition

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Build
-        run: docker compose exec -T frontend yarn build
+        run: docker compose exec -e NODE_ENV=production -T frontend yarn build
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Stop container

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from 'vite'
 
+const isProd = process.env.NODE_ENV === 'production';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [reactRouter(), tailwindcss()],
@@ -11,5 +13,6 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  base: "/LIMIT/",
+  // Use "/LIMIT/" when building for GitHub Pages, "/" during dev
+  base: isProd ? '/LIMIT/' : '/',
 })


### PR DESCRIPTION
This pull request introduces updates to improve the build process and environment configuration for both the deployment workflow and the Vite configuration. The most important changes include setting the `NODE_ENV` environment variable during the build step in the deployment workflow and dynamically configuring the `base` URL in the Vite configuration based on the environment.

### Deployment workflow improvements:
* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L42-R42): Updated the `Build` step to set the `NODE_ENV` environment variable to `production` when running the `yarn build` command. This ensures the build process uses the correct environment settings.

### Vite configuration enhancements:
* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR6-R7): Introduced a new `isProd` constant to detect the environment (`production` or development) based on the `NODE_ENV` environment variable.
* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL14-R17): Modified the `base` option in the Vite configuration to dynamically switch between `"/LIMIT/"` for production (e.g., GitHub Pages) and `"/"` for development. This improves flexibility for different deployment environments.## Issue URL