### PR TITLE
feat: remove base to use subdomain

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Build
-        run: docker compose exec -e NODE_ENV=production -T frontend yarn build
+        run: docker compose exec -T frontend yarn build
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Stop container

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,6 @@ import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from 'vite'
 
-const isProd = process.env.NODE_ENV === 'production';
-
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [reactRouter(), tailwindcss()],
@@ -13,6 +11,4 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  // Use "/LIMIT/" when building for GitHub Pages, "/" during dev
-  base: isProd ? '/LIMIT/' : '/',
 })


### PR DESCRIPTION
This pull request includes minor updates to streamline the build process and simplify the configuration files. The most important changes are related to the removal of unnecessary environment-specific logic and environment variables.

**Build process updates:**

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L42-R42): Removed the `NODE_ENV=production` environment variable from the `docker compose exec` command in the build step, as it is no longer required.

**Configuration simplifications:**

* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL6-L7): Removed the `isProd` constant and its usage in the `base` configuration, simplifying the build configuration by eliminating environment-specific logic. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL6-L7) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL16-L17)## Issue URL