### PR TITLE
chore: expand reviewer list

### DIFF
--- a/src/data/organizers.json
+++ b/src/data/organizers.json
@@ -114,12 +114,196 @@
   ],
   "reviewers": [
     {
-      "name": "Amir El-Ghoussani",
+      "name": "Aaqib Saeed",
       "affiliation": "Eindhoven University of Technology"
     },
     {
       "name": "Ahmed S. Abdelrahman",
       "affiliation": "University of Central Florida"
+    },
+    {
+      "name": "Alina Marcu",
+      "affiliation": "The National University of Science and Technology Politehnica Bucharest"
+    },
+    {
+      "name": "Amir El-Ghoussani",
+      "affiliation": "Friedrich-Alexander Universität Erlangen-Nürnberg"
+    },
+    {
+      "name": "Anestis Kastellos",
+      "affiliation": "Dimocritus University of Thrace"
+    },
+    {
+      "name": "Anubhav Paras",
+      "affiliation": "Zoox, Inc."
+    },
+    {
+      "name": "Atsushi Hashimoto",
+      "affiliation": "Keio University"
+    },
+    {
+      "name": "Binh M. Le",
+      "affiliation": "Sungkyunkwan University"
+    },
+    {
+      "name": "Carlos Rafael Catalan",
+      "affiliation": "Samsung Research"
+    },
+    {
+      "name": "Christoph Reich",
+      "affiliation": "University of Oxford"
+    },
+    {
+      "name": "Dheeraj Varghese",
+      "affiliation": "University of Amsterdam"
+    },
+    {
+      "name": "Emanuela Haller",
+      "affiliation": "UiPath"
+    },
+    {
+      "name": "Emil Slusanschi",
+      "affiliation": "University Politehnica of Bucharest"
+    },
+    {
+      "name": "Gaganpreet Jhajj",
+      "affiliation": "Athabasca University"
+    },
+    {
+      "name": "Hervé Le Borgne",
+      "affiliation": "CEA"
+    },
+    {
+      "name": "Ikuro Sato",
+      "affiliation": "Denso IT Laboratory, Inc."
+    },
+    {
+      "name": "Jiayi He",
+      "affiliation": "Georgia Institute of Technology"
+    },
+    {
+      "name": "Kazuya Nishimura",
+      "affiliation": "National Cancer Center Japan"
+    },
+    {
+      "name": "Khanh-Binh Nguyen",
+      "affiliation": "Deakin University"
+    },
+    {
+      "name": "Krishna Kanth Nakka",
+      "affiliation": "Huawei Technologies Ltd."
+    },
+    {
+      "name": "Min-Hung Chen",
+      "affiliation": "NVIDIA"
+    },
+    {
+      "name": "Minho Park",
+      "affiliation": "Korea Advanced Institute of Science & Technology"
+    },
+    {
+      "name": "Mücahid Barstuğan",
+      "affiliation": "Konya Technical University"
+    },
+    {
+      "name": "Naoshi Kaneko",
+      "affiliation": "Tokyo Denki University"
+    },
+    {
+      "name": "Naoya Chiba",
+      "affiliation": "Osaka University"
+    },
+    {
+      "name": "Noureldin Elmadany",
+      "affiliation": "Arab Academy for Science & Technology"
+    },
+    {
+      "name": "Pagon Gatchalee",
+      "affiliation": "Chiang Mai University"
+    },
+    {
+      "name": "Pengyu Dai",
+      "affiliation": "Tokyo Institute of Technology, Tokyo Institute of Technology"
+    },
+    {
+      "name": "Prahitha Movva",
+      "affiliation": "University of Massachusetts at Amherst"
+    },
+    {
+      "name": "Prajwal Singh",
+      "affiliation": "Indian Institute of Technology, Gandhinagar"
+    },
+    {
+      "name": "Purva Chiniya",
+      "affiliation": "Amazon"
+    },
+    {
+      "name": "Rakesh Chowdary Machineni",
+      "affiliation": "Rockwell Automation"
+    },
+    {
+      "name": "Ryuichi Nakahara",
+      "affiliation": "Okayama University"
+    },
+    {
+      "name": "Seungryong Kim",
+      "affiliation": "Korea Advanced Institute of Science & Technology"
+    },
+    {
+      "name": "Shashanka Venkataramanan",
+      "affiliation": "INRIA"
+    },
+    {
+      "name": "Shaurjya Mandal",
+      "affiliation": "Harvard University"
+    },
+    {
+      "name": "Shunsuke Kitada",
+      "affiliation": "LY Corp."
+    },
+    {
+      "name": "Sonain Jamil",
+      "affiliation": "Université Jean Monnet"
+    },
+    {
+      "name": "Tomoyuki Suzuki",
+      "affiliation": "CyberAgent"
+    },
+    {
+      "name": "Tsun-Yi Yang",
+      "affiliation": "Amazon"
+    },
+    {
+      "name": "Tushar Shinde",
+      "affiliation": "IIT Madras Zanzibar"
+    },
+    {
+      "name": "V Gurucharan",
+      "affiliation": "Collaborative Dynamics"
+    },
+    {
+      "name": "Wenhao You",
+      "affiliation": "University of Waterloo"
+    },
+    {
+      "name": "Yash Gupta",
+      "affiliation": "Headlands Technologies"
+    },
+    {
+      "name": "Youssef Dawoud",
+      "affiliation": "Friedrich-Alexander-Universität Erlangen-Nürnberg"
+    },
+    {
+      "name": "Yusuke Mukuta",
+      "affiliation": "The University of Tokyo"
+    },
+    {
+      "name": "Zhengkang Xiang",
+      "affiliation": "University of Melbourne"
+    },
+    {
+      "name": "Renaud Vandeghen",
+      "affiliation": "University of Liège"
     }
   ],
   "sponsors": [

--- a/src/data/organizers.json
+++ b/src/data/organizers.json
@@ -223,7 +223,7 @@
     },
     {
       "name": "Pengyu Dai",
-      "affiliation": "Tokyo Institute of Technology, Tokyo Institute of Technology"
+      "affiliation": "Tokyo Institute of Technology"
     },
     {
       "name": "Prahitha Movva",


### PR DESCRIPTION
## Summary
- add extensive set of reviewer names and affiliations to `organizers.json`

## Testing
- `yarn lint src/data/organizers.json` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fcaeb0e48326ae01395ca7f0125f