### PR TITLE
Add Google Search Console site verification meta tag

### DIFF
--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -29,6 +29,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="google-site-verification"
+          content="ji-hT4NRIusCUNz2z3vvVhqAUrEYfdUgEbj_Z-K39B0"
+        />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Summary
- add the Google Search Console verification meta tag to the document head so the homepage can be verified

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d14ad14e9083269e64744969cd0087