### PR TITLE
Enhance SEO metadata and add crawler support files

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://iccv2025-limit-workshop.limitlab.xyz/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://iccv2025-limit-workshop.limitlab.xyz/</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-limit-workshop.limitlab.xyz/call-for-papers</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-limit-workshop.limitlab.xyz/program</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-limit-workshop.limitlab.xyz/organizers</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-limit-workshop.limitlab.xyz/contact</loc>
+    <lastmod>2025-09-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 
 import type { Route } from "./+types/root";
+import { buildMeta } from "@/lib/seo";
 import "./app.css";
 
 export const links: Route.LinksFunction = () => [
@@ -22,6 +23,8 @@ export const links: Route.LinksFunction = () => [
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];
+
+export const meta: Route.MetaFunction = () => buildMeta();
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/routes/CallForPapers.tsx
+++ b/src/app/routes/CallForPapers.tsx
@@ -1,7 +1,7 @@
-import { Link } from "react-router";
-import { Download } from "lucide-react";
 import { Calendar } from "lucide-react";
+import { Download } from "lucide-react";
 import { ExternalLink } from "lucide-react";
+import { Link } from "react-router";
 
 import { Button } from "../../components/ui/button";
 // import {
@@ -12,6 +12,21 @@ import { Button } from "../../components/ui/button";
 // } from "../../components/ui/accordion";
 import callForPapersData from "../../data/callForPapers.json";
 import scheduleData from "../../data/schedule.json";
+import type { Route } from "./+types/CallForPapers";
+import { buildMeta } from "@/lib/seo";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title: "Call for Papers | LIMIT Workshop @ ICCV 2025",
+    description:
+      "Review topics, submission guidelines, and deadlines for the LIMIT Workshop call for papers at ICCV 2025. Submit via OpenReview and compete for best paper honors.",
+    path: "/call-for-papers",
+    keywords: [
+      "call for papers",
+      "OpenReview submissions",
+      "ICCV 2025 workshop deadlines",
+    ],
+  });
 
 function CallForPapers() {
   return (

--- a/src/app/routes/Contact.tsx
+++ b/src/app/routes/Contact.tsx
@@ -11,6 +11,17 @@ import {
 // import { Label } from "../../components/ui/label";
 // import { Textarea } from "../../components/ui/textarea";
 import contactData from "../../data/contact.json";
+import type { Route } from "./+types/Contact";
+import { buildMeta } from "@/lib/seo";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title: "Contact | LIMIT Workshop @ ICCV 2025",
+    description:
+      "Get in touch with the ICCV 2025 LIMIT Workshop team via email, venue information, and Slack, and review answers to frequently asked questions.",
+    path: "/contact",
+    keywords: ["contact information", "email", "workshop questions"],
+  });
 
 function Contact() {
   return (

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,9 +1,25 @@
-import { Link } from "react-router";
 import { Calendar, MapPin } from "lucide-react";
+import { Link } from "react-router";
 
 import { Button } from "../../components/ui/button";
 import homeData from "../../data/home.json";
 import scheduleData from "../../data/schedule.json";
+import type { Route } from "./+types/Home";
+import { buildMeta } from "@/lib/seo";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title:
+      "LIMIT Workshop @ ICCV 2025 | Representation Learning with Limited Resources",
+    description:
+      "LIMIT Workshop at ICCV 2025 spotlights resource-efficient representation learning. Join us on October 19 in Honolulu for keynotes, paper presentations, and community updates.",
+    path: "/",
+    keywords: [
+      "ICCV workshop 2025",
+      "resource-efficient vision",
+      "limited data learning",
+    ],
+  });
 
 function Home() {
   return (

--- a/src/app/routes/Organizers.tsx
+++ b/src/app/routes/Organizers.tsx
@@ -10,6 +10,17 @@ import {
   CardTitle,
 } from "../../components/ui/card";
 import organizersData from "../../data/organizers.json";
+import type { Route } from "./+types/Organizers";
+import { buildMeta } from "@/lib/seo";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title: "Organizers | LIMIT Workshop @ ICCV 2025",
+    description:
+      "Meet the organizing committee, program chairs, web chair, and reviewers supporting the ICCV 2025 LIMIT Workshop on resource-constrained representation learning.",
+    path: "/organizers",
+    keywords: ["organizing committee", "program chairs", "reviewers"],
+  });
 
 function Organizers() {
   return (

--- a/src/app/routes/Program.tsx
+++ b/src/app/routes/Program.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "lucide-react";
 import { Calendar, MapPin } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 import {
   Table,
@@ -21,7 +21,18 @@ import {
 
 import programData from "../../data/program.json";
 import scheduleData from "../../data/schedule.json";
+import type { Route } from "./+types/Program";
+import { buildMeta } from "@/lib/seo";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title: "Program | LIMIT Workshop @ ICCV 2025",
+    description:
+      "Explore the LIMIT Workshop program at ICCV 2025, featuring the detailed agenda, invited speakers, and accepted oral and poster papers on efficient learning from limited resources.",
+    path: "/program",
+    keywords: ["workshop agenda", "invited speakers", "accepted papers"],
+  });
 
 function Program() {
   return (

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,85 @@
+import type { MetaDescriptor } from "react-router";
+
+const SITE_URL = "https://iccv2025-limit-workshop.limitlab.xyz";
+const DEFAULT_IMAGE = `${SITE_URL}/limit-logo-white-wide.png`;
+const DEFAULT_IMAGE_ALT =
+  "LIMIT Workshop at ICCV 2025 wordmark on a dark gradient background";
+const SITE_NAME = "LIMIT Workshop @ ICCV 2025";
+const DEFAULT_DESCRIPTION =
+  "Official site for the ICCV 2025 LIMIT Workshop on representation learning with very limited data, labels, modalities, and compute.";
+const DEFAULT_KEYWORDS = [
+  "LIMIT Workshop",
+  "ICCV 2025",
+  "representation learning",
+  "resource-constrained AI",
+  "LIMIT Lab",
+  "efficient machine learning",
+];
+
+type SeoConfig = {
+  title?: string;
+  description?: string;
+  path?: string;
+  image?: string;
+  imageAlt?: string;
+  type?: string;
+  keywords?: string[];
+};
+
+const normalizePath = (path?: string) => {
+  if (!path || path === "/") {
+    return "";
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+};
+
+export function buildMeta(config: SeoConfig = {}): MetaDescriptor[] {
+  const {
+    title = SITE_NAME,
+    description = DEFAULT_DESCRIPTION,
+    path,
+    image = DEFAULT_IMAGE,
+    imageAlt = DEFAULT_IMAGE_ALT,
+    type = "website",
+    keywords = [],
+  } = config;
+
+  const canonicalPath = normalizePath(path);
+  const url = `${SITE_URL}${canonicalPath}`;
+  const keywordSet = new Set([
+    ...DEFAULT_KEYWORDS,
+    ...keywords.filter((keyword) => keyword.trim().length > 0),
+  ]);
+  const keywordContent = Array.from(keywordSet).join(", ");
+
+  const descriptors: MetaDescriptor[] = [
+    { title },
+    { name: "description", content: description },
+    ...(keywordContent ? [{ name: "keywords", content: keywordContent }] : []),
+    { property: "og:type", content: type },
+    { property: "og:site_name", content: SITE_NAME },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:url", content: url },
+    { property: "og:image", content: image },
+    { property: "og:image:alt", content: imageAlt },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    { name: "twitter:image", content: image },
+    { name: "twitter:image:alt", content: imageAlt },
+    { tagName: "link", rel: "canonical", href: url },
+  ];
+
+  return descriptors;
+}
+
+export const seoDefaults = {
+  SITE_NAME,
+  SITE_URL,
+  DEFAULT_DESCRIPTION,
+  DEFAULT_IMAGE,
+  DEFAULT_IMAGE_ALT,
+  DEFAULT_KEYWORDS,
+};


### PR DESCRIPTION
## Summary
- add a reusable SEO helper that centralizes default metadata
- define meta descriptors for the root layout and each user-facing route
- publish robots.txt and sitemap.xml so crawlers can index the workshop site

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d224a473f48326aac849b591df300a