### PR TITLE
Adjust workshop location formatting

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -3,7 +3,7 @@
   "subtitle": "ICCV 2025 Workshop",
   "eventInfo": {
     "date": "October 19, 2025, 1:00 PM – 6:00 PM (HST)",
-    "location": "Honolulu, Hawaii"
+    "location": "Hawaii Convention Center 306 A"
   },
   "overview": {
     "mission": "This workshop aims to bring together researchers and practitioners in the field of machine learning to discuss the latest advances and challenges in computer vision applications. We focus on innovative approaches, emerging techniques, and real-world implementations.",

--- a/src/data/schedule.json
+++ b/src/data/schedule.json
@@ -26,7 +26,7 @@
   "workshopProgram": {
     "day1": {
       "date": "October 19, 2025, 1:00 PM - 6:00 PM (HST)",
-      "location": "TBD",
+      "location": "Hawaii Convention Center 306 A",
       "schedule": [
         {
           "time": "13:00 - 13:10",
@@ -82,7 +82,7 @@
     },
     "day2": {
       "date": "October 16, 2025",
-      "location": "Room A3, Convention Center",
+      "location": "Hawaii Convention Center 306 A",
       "schedule": []
     }
   },


### PR DESCRIPTION
## Summary
- restore the home page meta description to its original Honolulu phrasing
- standardize the workshop location string to "Hawaii Convention Center 306 A" across home and schedule data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd76f5fe08326a1d5249f7a2f4164