### PR TITLE
Add PDF links beside accepted papers

### DIFF
--- a/src/app/routes/Program.tsx
+++ b/src/app/routes/Program.tsx
@@ -1,5 +1,4 @@
-import { Calendar, MapPin } from "lucide-react";
-import { ExternalLink } from "lucide-react";
+import { Calendar, MapPin, ExternalLink, FileText } from "lucide-react";
 
 import {
   Table,
@@ -266,7 +265,16 @@ function Program() {
       <section className="space-y-6">
         <div className="space-y-2">
           <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
-            Accepted Papers
+            Accepted Papers [
+            <a
+              href="https://openreview.net/group?id=thecvf.com/ICCV/2025/Workshop/LIMIT"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-primary"
+            >
+              Link
+            </a>
+            ]{" "}
           </h2>
         </div>
         <div className="relative border-border space-y-2">
@@ -282,9 +290,22 @@ function Program() {
           {programData.acceptedPapers.oral.map((paper, index) => (
             <div key={index} className="relative">
               <div className="space-y-1">
-                <h3 className="font-semibold">
-                  {paper.id}. {paper.title}
-                </h3>
+                <div className="flex items-start gap-2">
+                  <h3 className="font-semibold">
+                    {paper.id}. {paper.title}
+                  </h3>
+                  {paper.links?.paper && (
+                    <a
+                      href={paper.links.paper}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-1 text-primary hover:text-primary/80"
+                      aria-label={`Open PDF for ${paper.title}`}
+                    >
+                      <FileText className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
                 {/* <p className="text-muted-foreground flex items-center gap-2">
                   <Calendar className="h-4 w-4" />
                   {date.date}
@@ -337,9 +358,22 @@ function Program() {
           {programData.acceptedPapers.poster.map((paper, index) => (
             <div key={index} className="relative">
               <div className="space-y-1">
-                <h3 className="font-semibold">
-                  {paper.id}. {paper.title}
-                </h3>
+                <div className="flex items-start gap-2">
+                  <h3 className="font-semibold">
+                    {paper.id}. {paper.title}
+                  </h3>
+                  {paper.links?.paper && (
+                    <a
+                      href={paper.links.paper}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-1 text-primary hover:text-primary/80"
+                      aria-label={`Open PDF for ${paper.title}`}
+                    >
+                      <FileText className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
                 {/* <p className="text-muted-foreground flex items-center gap-2">
                   <Calendar className="h-4 w-4" />
                   {date.date}

--- a/src/data/program.json
+++ b/src/data/program.json
@@ -42,8 +42,7 @@
         "title": "Memory-Efficient Personalization of Text-to-Image Diffusion Models via Selective Optimization Strategies",
         "authors": "Seokeon Choi, Sunghyun Park, Hyoungwoo Park, Jeongho Kim, Sungrack Yun",
         "links": {
-          "paper": "#",
-          "video": "#"
+          "paper": "https://openreview.net/attachment?id=xl0yrpO1eY&name=pdf"
         }
       },
       {
@@ -51,8 +50,7 @@
         "title": "Joint Training of Image Generator and Detector for Road Defect Detection",
         "authors": "Kuan-Chuan Peng",
         "links": {
-          "paper": "#",
-          "video": "#"
+          "paper": "https://openreview.net/attachment?id=yPtMwCa1hO&name=pdf"
         }
       },
       {
@@ -60,8 +58,7 @@
         "title": "Intraclass Compactness: A Metric for Evaluating Models Pre-Trained on Various Synthetic Data",
         "authors": "Tomoki Suzuki, Kazuki Maeno, Yasunori Ishii, Takayoshi Yamashita",
         "links": {
-          "paper": "#",
-          "video": "#"
+          "paper": "https://openreview.net/attachment?id=G2WCuOVVti&name=pdf"
         }
       },
       {
@@ -69,8 +66,7 @@
         "title": "AutoQ-VIS: Improving Unsupervised Video Instance Segmentation via Automatic Quality Assessment",
         "authors": "Kaixuan Lu, Mehmet Onurcan Kaya, Dim Papadopoulos",
         "links": {
-          "paper": "#",
-          "video": "#"
+          "paper": "https://openreview.net/attachment?id=fvU29KaaFc&name=pdf"
         }
       }
     ],
@@ -80,7 +76,7 @@
         "title": "Look but Don't Touch: Gradient Informed Selection Training",
         "authors": "David Mayo, Chris Zhang, Boris Katz, Andrei Barbu, Brian Cheung",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=e7zmFky688&name=pdf"
         }
       },
       {
@@ -88,7 +84,7 @@
         "title": "Efficiently Generating Multidimensional Calorimeter Data with Tensor Decomposition Parameterization",
         "authors": "Paimon Goulart, Shaan Pakala, Evangelos E. Papalexakis",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=TOPq08zskO&name=pdf"
         }
       },
       {
@@ -96,7 +92,7 @@
         "title": "QR-LoRA: QR-Based Low-Rank Adaptation for Efficient Fine-Tuning of Large Language Models",
         "authors": "Jessica E. Liang, Anirudh Bharadwaj",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=HxUgAqehGP&name=pdf"
         }
       },
       {
@@ -104,7 +100,7 @@
         "title": "Attn-Adapter: Attention is all you need for Online Few-shot Learner of Vision-Language Model",
         "authors": "Phuoc-Nguyen Bui, Khanh-Binh Nguyen, Hyunseung Choo",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=3VY0Foh061&name=pdf"
         }
       },
       {
@@ -112,7 +108,7 @@
         "title": "Cross-task knowledge distillation for few-shot detection",
         "authors": "Louis Hémadou, Héléna Vorobieva, Ahmed Nasreddine Benaichouche, Frederic Jurie, Ewa Kijak",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=fr0vkjd7MY&name=pdf"
         }
       },
       {
@@ -120,7 +116,7 @@
         "title": "NoiseCutMix: A Novel Data Augmentation Approach by Mixing Estimated Noise in Diffusion Models",
         "authors": "Shumpei Takezaki, Ryoma Bise, Shinnosuke Matsuo",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=IcuXq2Z0Rz&name=pdf"
         }
       },
       {
@@ -128,7 +124,7 @@
         "title": "Efficient Masked Attention Transformer for Few-Shot Classification and Segmentation",
         "authors": "Dustin Carrión-Ojeda, Stefan Roth, Simone Schaub-Meyer",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=9YBgADS4p8&name=pdf"
         }
       },
       {
@@ -136,7 +132,7 @@
         "title": "Resource-Efficient Time-Series Forecasting of Displacement Imagery using Koopman Autoencoders",
         "authors": "Takayuki Shinohara, Hidetaka Saomoto",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=n6YYiO15iy&name=pdf"
         }
       },
       {
@@ -144,7 +140,7 @@
         "title": "Fake & Square: Training Self-Supervised Vision Transformers with Synthetic Data and Synthetic Hard Negatives",
         "authors": "Nikolaos Giakoumoglou, Andreas Floros, Kleanthis Marios Papadopoulos, Tania Stathaki",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=TJUfbYKo2c&name=pdf"
         }
       },
       {
@@ -152,7 +148,7 @@
         "title": "Learning Video Representations without Natural Videos",
         "authors": "Xueyang Yu, Xinlei Chen, Yossi Gandelsman",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=nqDXwTTCWA&name=pdf"
         }
       },
       {
@@ -160,7 +156,7 @@
         "title": "OFASD: One-Shot Federated Anisotropic Scaling Distillation",
         "authors": "Shunsei Koshibuchi, Hiroshi Kera, Kazuhiko Kawamoto",
         "links": {
-          "paper": "#"
+          "paper": "https://openreview.net/attachment?id=T4Ong6jjGu&name=pdf"
         }
       },
       {
@@ -168,7 +164,7 @@
         "title": "Invited poster 1",
         "authors": "NeurIPS 2025 accepted paper",
         "links": {
-          "paper": "#"
+          "paper": ""
         }
       },
       {
@@ -176,7 +172,7 @@
         "title": "Invited poster 2",
         "authors": "TBD",
         "links": {
-          "paper": "#"
+          "paper": ""
         }
       },
       {
@@ -184,7 +180,7 @@
         "title": "Invited poster 3",
         "authors": "TBD",
         "links": {
-          "paper": "#"
+          "paper": ""
         }
       },
       {
@@ -192,7 +188,7 @@
         "title": "Invited poster 4",
         "authors": "TBD",
         "links": {
-          "paper": "#"
+          "paper": ""
         }
       },
       {
@@ -200,7 +196,7 @@
         "title": "Invited poster 5",
         "authors": "TBD",
         "links": {
-          "paper": "#"
+          "paper": ""
         }
       }
     ]


### PR DESCRIPTION
## Summary
- update accepted paper entries with PDF URLs
- render a PDF icon next to each accepted paper title linked to the document

## Testing
- not run (read-only sandbox)