### PR TITLE
Add poster board details to program

### DIFF
--- a/src/app/routes/Program.tsx
+++ b/src/app/routes/Program.tsx
@@ -305,6 +305,11 @@ function Program() {
                       <FileText className="h-4 w-4" />
                     </a>
                   )}
+                  {paper.posterBoard && (
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                      Poster Board {paper.posterBoard}
+                    </span>
+                  )}
                 </div>
                 {/* <p className="text-muted-foreground flex items-center gap-2">
                   <Calendar className="h-4 w-4" />
@@ -351,7 +356,8 @@ function Program() {
             >
               ICCV official website
             </a>
-            .
+            . Please display your poster on the assigned poster board number in{" "}
+            <span className="font-semibold">Exhibit Hall II</span>.
           </p>
         </div>
         <div className="relative border-border space-y-8">
@@ -372,6 +378,11 @@ function Program() {
                     >
                       <FileText className="h-4 w-4" />
                     </a>
+                  )}
+                  {paper.posterBoard && (
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                      Poster Board {paper.posterBoard}
+                    </span>
                   )}
                 </div>
                 {/* <p className="text-muted-foreground flex items-center gap-2">

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -35,6 +35,11 @@
   ],
   "latestNews": [
     {
+      "title": "Poster board numbers added",
+      "date": "October 15, 2025",
+      "content": "Poster board numbers have been added to the Program page."
+    },
+    {
       "title": "List of acepted papers released",
       "date": "September 9, 2025",
       "content": "We are pleased to announce that the list of accepted papers for our workshop is now available."

--- a/src/data/program.json
+++ b/src/data/program.json
@@ -41,6 +41,7 @@
         "id": 1,
         "title": "Memory-Efficient Personalization of Text-to-Image Diffusion Models via Selective Optimization Strategies",
         "authors": "Seokeon Choi, Sunghyun Park, Hyoungwoo Park, Jeongho Kim, Sungrack Yun",
+        "posterBoard": 63,
         "links": {
           "paper": "https://openreview.net/attachment?id=xl0yrpO1eY&name=pdf"
         }
@@ -49,6 +50,7 @@
         "id": 2,
         "title": "Joint Training of Image Generator and Detector for Road Defect Detection",
         "authors": "Kuan-Chuan Peng",
+        "posterBoard": 64,
         "links": {
           "paper": "https://openreview.net/attachment?id=yPtMwCa1hO&name=pdf"
         }
@@ -57,6 +59,7 @@
         "id": 3,
         "title": "Intraclass Compactness: A Metric for Evaluating Models Pre-Trained on Various Synthetic Data",
         "authors": "Tomoki Suzuki, Kazuki Maeno, Yasunori Ishii, Takayoshi Yamashita",
+        "posterBoard": 65,
         "links": {
           "paper": "https://openreview.net/attachment?id=G2WCuOVVti&name=pdf"
         }
@@ -65,6 +68,7 @@
         "id": 4,
         "title": "AutoQ-VIS: Improving Unsupervised Video Instance Segmentation via Automatic Quality Assessment",
         "authors": "Kaixuan Lu, Mehmet Onurcan Kaya, Dim Papadopoulos",
+        "posterBoard": 66,
         "links": {
           "paper": "https://openreview.net/attachment?id=fvU29KaaFc&name=pdf"
         }
@@ -75,6 +79,7 @@
         "id": 5,
         "title": "Look but Don't Touch: Gradient Informed Selection Training",
         "authors": "David Mayo, Chris Zhang, Boris Katz, Andrei Barbu, Brian Cheung",
+        "posterBoard": 67,
         "links": {
           "paper": "https://openreview.net/attachment?id=e7zmFky688&name=pdf"
         }
@@ -83,6 +88,7 @@
         "id": 6,
         "title": "Efficiently Generating Multidimensional Calorimeter Data with Tensor Decomposition Parameterization",
         "authors": "Paimon Goulart, Shaan Pakala, Evangelos E. Papalexakis",
+        "posterBoard": 68,
         "links": {
           "paper": "https://openreview.net/attachment?id=TOPq08zskO&name=pdf"
         }
@@ -91,6 +97,7 @@
         "id": 7,
         "title": "QR-LoRA: QR-Based Low-Rank Adaptation for Efficient Fine-Tuning of Large Language Models",
         "authors": "Jessica E. Liang, Anirudh Bharadwaj",
+        "posterBoard": 69,
         "links": {
           "paper": "https://openreview.net/attachment?id=HxUgAqehGP&name=pdf"
         }
@@ -99,6 +106,7 @@
         "id": 8,
         "title": "Attn-Adapter: Attention is all you need for Online Few-shot Learner of Vision-Language Model",
         "authors": "Phuoc-Nguyen Bui, Khanh-Binh Nguyen, Hyunseung Choo",
+        "posterBoard": 70,
         "links": {
           "paper": "https://openreview.net/attachment?id=3VY0Foh061&name=pdf"
         }
@@ -107,6 +115,7 @@
         "id": 9,
         "title": "Cross-task knowledge distillation for few-shot detection",
         "authors": "Louis Hémadou, Héléna Vorobieva, Ahmed Nasreddine Benaichouche, Frederic Jurie, Ewa Kijak",
+        "posterBoard": 71,
         "links": {
           "paper": "https://openreview.net/attachment?id=fr0vkjd7MY&name=pdf"
         }
@@ -115,6 +124,7 @@
         "id": 10,
         "title": "NoiseCutMix: A Novel Data Augmentation Approach by Mixing Estimated Noise in Diffusion Models",
         "authors": "Shumpei Takezaki, Ryoma Bise, Shinnosuke Matsuo",
+        "posterBoard": 72,
         "links": {
           "paper": "https://openreview.net/attachment?id=IcuXq2Z0Rz&name=pdf"
         }
@@ -123,6 +133,7 @@
         "id": 11,
         "title": "Efficient Masked Attention Transformer for Few-Shot Classification and Segmentation",
         "authors": "Dustin Carrión-Ojeda, Stefan Roth, Simone Schaub-Meyer",
+        "posterBoard": 73,
         "links": {
           "paper": "https://openreview.net/attachment?id=9YBgADS4p8&name=pdf"
         }
@@ -131,6 +142,7 @@
         "id": 12,
         "title": "Resource-Efficient Time-Series Forecasting of Displacement Imagery using Koopman Autoencoders",
         "authors": "Takayuki Shinohara, Hidetaka Saomoto",
+        "posterBoard": 74,
         "links": {
           "paper": "https://openreview.net/attachment?id=n6YYiO15iy&name=pdf"
         }
@@ -139,6 +151,7 @@
         "id": 13,
         "title": "Fake & Square: Training Self-Supervised Vision Transformers with Synthetic Data and Synthetic Hard Negatives",
         "authors": "Nikolaos Giakoumoglou, Andreas Floros, Kleanthis Marios Papadopoulos, Tania Stathaki",
+        "posterBoard": 75,
         "links": {
           "paper": "https://openreview.net/attachment?id=TJUfbYKo2c&name=pdf"
         }
@@ -147,6 +160,7 @@
         "id": 14,
         "title": "Learning Video Representations without Natural Videos",
         "authors": "Xueyang Yu, Xinlei Chen, Yossi Gandelsman",
+        "posterBoard": 76,
         "links": {
           "paper": "https://openreview.net/attachment?id=nqDXwTTCWA&name=pdf"
         }
@@ -155,6 +169,7 @@
         "id": 15,
         "title": "OFASD: One-Shot Federated Anisotropic Scaling Distillation",
         "authors": "Shunsei Koshibuchi, Hiroshi Kera, Kazuhiko Kawamoto",
+        "posterBoard": 77,
         "links": {
           "paper": "https://openreview.net/attachment?id=T4Ong6jjGu&name=pdf"
         }
@@ -163,6 +178,7 @@
         "id": 16,
         "title": "Invited poster 1",
         "authors": "NeurIPS 2025 accepted paper",
+        "posterBoard": 78,
         "links": {
           "paper": ""
         }
@@ -171,6 +187,7 @@
         "id": 17,
         "title": "Unified Category-Level Object Detection and Pose Estimation from RGB Images using 3D Prototypes",
         "authors": "Tom Fischer, Xiaojie Zhang, Eddy Ilg",
+        "posterBoard": 79,
         "links": {
           "paper": "https://arxiv.org/abs/2508.02157"
         }
@@ -179,6 +196,7 @@
         "id": 18,
         "title": "DACoN: DINO for Anime Paint Bucket Colorization with Any Number of Reference Images",
         "authors": "Kazuma Nagata, Naoshi Kaneko",
+        "posterBoard": 80,
         "links": {
           "paper": "https://arxiv.org/abs/2509.14685"
         }
@@ -187,6 +205,7 @@
         "id": 19,
         "title": "Industrial Synthetic Segment Pre-training",
         "authors": "Shinichi Mae, Ryousuke Yamada, Hirokatsu Kataoka",
+        "posterBoard": 81,
         "links": {
           "paper": "https://arxiv.org/abs/2505.13099"
         }
@@ -195,6 +214,7 @@
         "id": 20,
         "title": "TWIST & SCOUT: Grounding Multimodal LLM-Experts by Forget-Free Tuning",
         "authors": "Aritra Bhowmik, Mohammad Mahdi Derakhshani, Dennis Koelma, Yuki M. Asano, Martin R. Oswald, Cees G. M. Snoek",
+        "posterBoard": 82,
         "links": {
           "paper": "https://arxiv.org/abs/2410.10491"
         }


### PR DESCRIPTION
## Summary
- show poster board numbers for each accepted paper in the program
- update program instructions with display location details
- add a latest news entry announcing poster board numbers