### PR TITLE
Add awards page and update navigation

### DIFF
--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -11,6 +11,7 @@ export default [
     route("/call-for-papers", "./routes/CallForPapers.tsx"),
     // route("/schedule", "./routes/Schedule.tsx"),
     route("/program", "./routes/Program.tsx"),
+    route("/awards", "./routes/Awards.tsx"),
     route("/organizers", "./routes/Organizers.tsx"),
     // route("/past-events", "./routes/PastEvents.tsx"),
     route("/contact", "./routes/Contact.tsx"),

--- a/src/app/routes/Awards.tsx
+++ b/src/app/routes/Awards.tsx
@@ -1,0 +1,100 @@
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "../../components/ui/card";
+import awardsData from "../../data/awards.json";
+import type { Route } from "./+types/Awards";
+import { buildMeta } from "@/lib/seo";
+
+export const meta: Route.MetaFunction = () =>
+  buildMeta({
+    title: "Awards | LIMIT Workshop @ ICCV 2025",
+    description:
+      "Celebrate the LIMIT Workshop award recipients, honoring outstanding contributions across accepted papers at ICCV 2025.",
+    path: "/awards",
+    keywords: [
+      "LIMIT Workshop awards",
+      "Best Paper LIMIT",
+      "ICCV 2025 workshop awards",
+      "LIMIT accepted papers",
+    ],
+  });
+
+function Awards() {
+  return (
+    <main className="container px-6 py-8 space-y-12 xl:w-6xl">
+      <section className="space-y-4 text-center">
+        {/* <div className="flex justify-center">
+          <AwardIcon className="h-12 w-12 text-primary" />
+        </div> */}
+        <h1 className="text-3xl sm:text-4xl tracking-tighter">
+          {awardsData.title}
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+          {awardsData.subtitle}
+        </p>
+        {/* <p className="text-muted-foreground max-w-3xl mx-auto">
+          {awardsData.intro}
+        </p> */}
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
+            Best Paper Award
+          </h2>
+        </div>
+        <div className="grid gap-6 grid-cols-1">
+          {awardsData.awards.map((award) => (
+            <Card key={award.paperTitle} className="flex flex-col w-full">
+              <CardHeader className="space-y-3">
+                {/* <div className="flex items-center gap-2 text-xl font-semibold text-primary">
+                  <AwardIcon className="h-4 w-4" />
+                  <span>{award.category}</span>
+                </div> */}
+                <CardTitle className="text-xl leading-tight">
+                  {award.paperTitle}
+                </CardTitle>
+                <CardDescription className="text-base sm:text-md">
+                  {award.authors}
+                </CardDescription>
+              </CardHeader>
+              {/* <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  {award.summary}
+                </p>
+              </CardContent> */}
+              <CardFooter className="mt-auto flex flex-col gap-4 items-center">
+                {/* <Button variant="outline" size="sm" asChild>
+                  <a href={award.paperLink} target="_blank" rel="noreferrer">
+                    Read paper
+                    <ExternalLink className="ml-2 h-3 w-3" />
+                  </a>
+                </Button> */}
+                <div className="flex justify-center w-full">
+                  <img
+                    src="/limit-logo-black-wide.png"
+                    alt="LIMIT Workshop logo"
+                    className="h-30 w-auto dark:hidden"
+                    loading="lazy"
+                  />
+                  <img
+                    src="/limit-logo-white-wide.png"
+                    alt="LIMIT Workshop logo"
+                    className="h-30 w-auto hidden dark:block"
+                    loading="lazy"
+                  />
+                </div>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default Awards;

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -138,6 +138,18 @@ export function Footer() {
             Program
           </Link>
           <Link
+            to="/awards"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Awards
+          </Link>
+          <Link
+            to="/organizers"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Organizers
+          </Link>
+          <Link
             to="/contact"
             className="text-sm text-muted-foreground hover:text-foreground"
           >

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -18,6 +18,7 @@ const navItems = [
   { name: "Call for Papers", path: "/call-for-papers" },
   // { name: "Schedule", path: "/schedule" },
   { name: "Program", path: "/program" },
+  { name: "Awards", path: "/awards" },
   { name: "Organizers", path: "/organizers" },
   // { name: "Past Events", path: "/past-events" },
   { name: "Contact", path: "/contact" },

--- a/src/data/awards.json
+++ b/src/data/awards.json
@@ -1,0 +1,62 @@
+{
+  "title": "Awards",
+  "subtitle": "Recognizing outstanding contributions from the LIMIT Workshop accepted papers",
+  "intro": "We are delighted to highlight the papers that demonstrated exceptional insight, rigor, and real-world impact within the LIMIT community. These awards reflect the collective recommendations of the program committee and invited reviewers.",
+  "awards": [
+    {
+      "category": "Best Paper Award",
+      "paperTitle": "Memory-Efficient Personalization of Text-to-Image Diffusion Models via Selective Optimization Strategies",
+      "authors": "Seokeon Choi, Sunghyun Park, Hyoungwoo Park, Jeongho Kim, Sungrack Yun",
+      "paperLink": "https://openreview.net/attachment?id=xl0yrpO1eY&name=pdf",
+      "summary": "Introduces a mixed optimization pipeline that achieves state-of-the-art personalization quality while reducing memory and compute requirements, making high-fidelity diffusion adaptation accessible on resource-constrained systems."
+    }
+  ],
+  "honorableMentions": [
+    {
+      "paperTitle": "NoiseCutMix: A Novel Data Augmentation Approach by Mixing Estimated Noise in Diffusion Models",
+      "authors": "Shumpei Takezaki, Ryoma Bise, Shinnosuke Matsuo",
+      "paperLink": "https://openreview.net/attachment?id=8jAc6z19hE&name=pdf",
+      "summary": "Delivers consistent accuracy gains across diffusion-based augmentations without increasing training cost, proving effective on noisy few-shot benchmarks."
+    },
+    {
+      "paperTitle": "Attn-Adapter: Attention is all you need for Online Few-shot Learner of Vision-Language Model",
+      "authors": "Phuoc-Nguyen Bui, Khanh-Binh Nguyen, Hyunseung Choo",
+      "paperLink": "https://openreview.net/attachment?id=3VY0Foh061&name=pdf",
+      "summary": "Demonstrates a lightweight attention adapter that rapidly personalizes large vision-language models, closing the gap between static pre-training and real-time adaptation."
+    }
+  ],
+  "selection": {
+    "overview": "The awards committee evaluated all eligible papers from the oral and poster tracks, considering reviewer feedback, presentation quality, and post-review updates submitted by authors.",
+    "criteria": [
+      "Novelty and technical rigor in addressing the challenges of learning with limited supervision, compute, or modalities.",
+      "Clarity of presentation and reproducibility of the proposed method.",
+      "Demonstrated or potential impact on real-world deployments under constrained resources."
+    ],
+    "committee": [
+      "Hirokatsu Kataoka (AIST / Oxford VGG)",
+      "Yuki M. Asano (University of Technology Nuremberg)",
+      "Iro Laina (Oxford VGG)"
+    ]
+  },
+  "timeline": [
+    {
+      "phase": "Nominations",
+      "date": "September 10, 2025",
+      "description": "Area chairs and reviewers nominated standout submissions based on written reviews and author rebuttals."
+    },
+    {
+      "phase": "Final Deliberation",
+      "date": "September 22, 2025",
+      "description": "Awards committee met to compare short-listed papers and confirm the final selections."
+    },
+    {
+      "phase": "Announcement",
+      "date": "October 16, 2025",
+      "description": "Award recipients were announced during the LIMIT Workshop closing session at ICCV 2025."
+    }
+  ],
+  "cta": {
+    "text": "Interested in partnering with LIMIT to support future awards or industry challenges?",
+    "email": "limit-workshop@limitlab.xyz"
+  }
+}

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -40,6 +40,11 @@
       "content": "The workshop was successfully held with many participants. We sincerely thank all presenters and contributors for their valuable contributions."
     },
     {
+      "title": "Awards announced",
+      "date": "October 19, 2025",
+      "content": "We have announced the award recipients for the LIMIT Workshop."
+    },
+    {
       "title": "Poster board numbers added",
       "date": "October 15, 2025",
       "content": "Poster board numbers have been added to the Program page."


### PR DESCRIPTION
## Summary
- add dedicated awards route wired into the router
- surface awards in header/footer navigation and latest news
- add structured awards data for best paper and mentions

## Testing
- not run (not requested)
